### PR TITLE
Bring in line with SignalControl

### DIFF
--- a/examples/Signal4Aspect/Signal4Aspect.ino
+++ b/examples/Signal4Aspect/Signal4Aspect.ino
@@ -25,6 +25,7 @@ void setup()
 {
   ledStrip.setBrightness(40);
   ledStrip.setTemperature(Tungsten100W);
+  signal1.begin();
 }
 
 void loop() 

--- a/src/SmartLedLight.h
+++ b/src/SmartLedLight.h
@@ -26,6 +26,11 @@ public:
     return lightOn;
   }
 
+  virtual void begin() override
+  {
+    //pinMode(lightPin, OUTPUT);
+  }
+
   CRGB::HTMLColorCode getColor() const
   {
     return color;


### PR DESCRIPTION
I have added an empty begin() function in SmartLedLight.h. I have also put a call signal1.begin() into the setup() of the example. This does not do anything - it shows how begin() should be used if things are added later. I notice that in this case the pin number is passed at compile time as a template parameter. The changed code compiles. I have not tested it on actual hardware. John